### PR TITLE
feat(Decorators): Add the `constant` decorator

### DIFF
--- a/API.md
+++ b/API.md
@@ -18,7 +18,7 @@ import/awaits.</p>
 <dd><p>Apply special props to the given function from another one</p>
 </dd>
 <dt><a href="#wrapInitializer">wrapInitializer(wrapper, baseInitializer)</a> ⇒ <code>function</code></dt>
-<dd><p>Allows to wrap an initializer to add extra</p>
+<dd><p>Allows to wrap an initializer to add extra initialization steps</p>
 </dd>
 <dt><a href="#inject">inject(dependenciesDeclarations, initializer, [merge])</a> ⇒ <code>function</code></dt>
 <dd><p>Decorator creating a new initializer with some
@@ -42,6 +42,9 @@ import/awaits.</p>
 </dd>
 <dt><a href="#initializer">initializer(properties, initializer)</a> ⇒ <code>function</code></dt>
 <dd><p>Decorator to set an initializer properties.</p>
+</dd>
+<dt><a href="#constant">constant(name, initializer)</a> ⇒ <code>function</code></dt>
+<dd><p>Decorator that creates an initializer for a constant value</p>
 </dd>
 <dt><a href="#handler">handler(handlerFunction, [dependencies], [extra])</a> ⇒ <code>function</code></dt>
 <dd><p>Shortcut to create an initializer with a simple handler</p>
@@ -85,7 +88,7 @@ const $ = new Knifecycle();
 <a name="Knifecycle+constant"></a>
 
 ### knifecycle.constant(constantName, constantValue) ⇒ [<code>Knifecycle</code>](#Knifecycle)
-Register a constant service
+Register a constant initializer
 
 **Kind**: instance method of [<code>Knifecycle</code>](#Knifecycle)  
 **Returns**: [<code>Knifecycle</code>](#Knifecycle) - The Knifecycle instance (for chaining)  
@@ -344,7 +347,7 @@ Apply special props to the given function from another one
 <a name="wrapInitializer"></a>
 
 ## wrapInitializer(wrapper, baseInitializer) ⇒ <code>function</code>
-Allows to wrap an initializer to add extra
+Allows to wrap an initializer to add extra initialization steps
 
 **Kind**: global function  
 **Returns**: <code>function</code> - The new initializer  
@@ -507,6 +510,26 @@ getInstance()
   inject: ['ENV'],
   options: { singleton: true }
 }, myServiceInitializer));
+```
+<a name="constant"></a>
+
+## constant(name, initializer) ⇒ <code>function</code>
+Decorator that creates an initializer for a constant value
+
+**Kind**: global function  
+**Returns**: <code>function</code> - Returns a new initializer  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| name | <code>String</code> | The constant's name. |
+| initializer | <code>any</code> | The constant's value |
+
+**Example**  
+```js
+import { constant, getInstance } from 'knifecycle';
+
+getInstance()
+  .register(constant('THE_NUMBER', value));
 ```
 <a name="handler"></a>
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,7 +22,7 @@ It is designed to have a low footprint on services code.
  can be reused elsewhere (even when not using DI) with no changes
  at all.
 
-[See in context](./src/index.js#L45-L59)
+[See in context](./src/index.js#L49-L63)
 
 
 
@@ -37,7 +37,7 @@ A service provider is full of state since its concern is
  [encapsulate](https://en.wikipedia.org/wiki/Encapsulation_(computer_programming))
  your application global states.
 
-[See in context](./src/index.js#L61-L70)
+[See in context](./src/index.js#L65-L74)
 
 
 
@@ -83,7 +83,7 @@ Initializers can be of two types:
   executions silos using them (we will cover this
   topic later on).
 
-[See in context](./src/index.js#L146-L171)
+[See in context](./src/index.js#L150-L175)
 
 
 
@@ -97,7 +97,7 @@ The `?` flag indicates an optionnal dependencies.
  It allows to write generic services with fixed
  dependencies and remap their name at injection time.
 
-[See in context](./src/util.js#L311-L320)
+[See in context](./src/util.js#L367-L376)
 
 
 
@@ -113,7 +113,7 @@ Depending of your application design, you could run it
  in only one execution silo or into several ones
  according to the isolation level your wish to reach.
 
-[See in context](./src/index.js#L479-L489)
+[See in context](./src/index.js#L489-L499)
 
 
 

--- a/README.md
+++ b/README.md
@@ -396,6 +396,9 @@ import/awaits.</p>
 <dt><a href="#initializer">initializer(properties, initializer)</a> ⇒ <code>function</code></dt>
 <dd><p>Decorator to set an initializer properties.</p>
 </dd>
+<dt><a href="#constant">constant(name, initializer)</a> ⇒ <code>function</code></dt>
+<dd><p>Decorator that creates an initializer for a constant value</p>
+</dd>
 <dt><a href="#handler">handler(handlerFunction, [dependencies], [extra])</a> ⇒ <code>function</code></dt>
 <dd><p>Shortcut to create an initializer with a simple handler</p>
 </dd>
@@ -412,7 +415,7 @@ import/awaits.</p>
 * [Knifecycle](#Knifecycle)
     * [new Knifecycle()](#new_Knifecycle_new)
     * _instance_
-        * [.constant(constantName, constantValue)](#Knifecycle+constant) ⇒ [<code>Knifecycle</code>](#Knifecycle)
+        * ~~[.constant(constantName, constantValue)](#Knifecycle+constant) ⇒ [<code>Knifecycle</code>](#Knifecycle)~~
         * [.service(serviceName, initializer, options)](#Knifecycle+service) ⇒ [<code>Knifecycle</code>](#Knifecycle)
         * [.provider(serviceName, initializer, options)](#Knifecycle+provider) ⇒ [<code>Knifecycle</code>](#Knifecycle)
         * [.toMermaidGraph(options)](#Knifecycle+toMermaidGraph) ⇒ <code>String</code>
@@ -437,8 +440,10 @@ const $ = new Knifecycle();
 ```
 <a name="Knifecycle+constant"></a>
 
-### knifecycle.constant(constantName, constantValue) ⇒ [<code>Knifecycle</code>](#Knifecycle)
-Register a constant service
+### ~~knifecycle.constant(constantName, constantValue) ⇒ [<code>Knifecycle</code>](#Knifecycle)~~
+***Deprecated***
+
+Register a constant initializer
 
 **Kind**: instance method of [<code>Knifecycle</code>](#Knifecycle)  
 **Returns**: [<code>Knifecycle</code>](#Knifecycle) - The Knifecycle instance (for chaining)  
@@ -860,6 +865,26 @@ getInstance()
   inject: ['ENV'],
   options: { singleton: true }
 }, myServiceInitializer));
+```
+<a name="constant"></a>
+
+## constant(name, initializer) ⇒ <code>function</code>
+Decorator that creates an initializer for a constant value
+
+**Kind**: global function  
+**Returns**: <code>function</code> - Returns a new initializer  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| name | <code>String</code> | The constant's name. |
+| initializer | <code>any</code> | The constant's value |
+
+**Example**  
+```js
+import { constant, getInstance } from 'knifecycle';
+
+getInstance()
+  .register(constant('THE_NUMBER', value));
 ```
 <a name="handler"></a>
 

--- a/src/util.mocha.js
+++ b/src/util.mocha.js
@@ -10,6 +10,7 @@ import {
   options,
   extra,
   initializer,
+  constant,
   handler,
   SPECIAL_PROPS,
 } from './util';
@@ -198,6 +199,30 @@ describe('initializer', () => {
     assert.deepEqual(newInitializer[SPECIAL_PROPS.OPTIONS], baseOptions);
     assert.equal(newInitializer[SPECIAL_PROPS.NAME], baseName);
     assert.equal(newInitializer[SPECIAL_PROPS.TYPE], baseType);
+  });
+});
+
+describe('constant', () => {
+  it('should allow to create an initializer from a constant', async () => {
+    const baseValue = 'THE_VALUE';
+    const baseName = 42;
+    const newInitializer = constant(baseName, baseValue);
+
+    assert.notEqual(newInitializer, aProvider);
+    assert.deepEqual(newInitializer[SPECIAL_PROPS.INJECT], []);
+    assert.deepEqual(newInitializer[SPECIAL_PROPS.OPTIONS], {
+      singleton: true,
+    });
+    assert.equal(newInitializer[SPECIAL_PROPS.NAME], baseName);
+    assert.equal(newInitializer[SPECIAL_PROPS.TYPE], 'constant');
+    assert.equal(newInitializer[SPECIAL_PROPS.VALUE], baseValue);
+    assert.equal(await newInitializer(), baseValue);
+  });
+
+  it('should fail with dependencies since it makes no sense', () => {
+    assert.throws(() => {
+      constant('time', inject(['hash3'], async () => {}));
+    }, /E_CONSTANT_INJECTION/);
   });
 });
 


### PR DESCRIPTION
Currently the only way to create a constant was to instanciate a `Knifecycle` instance. This allows
to create and register constants separately.

fix #60