### PR TITLE
refactor(types): fix using knifecycle with strict types

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,7 +24,7 @@ It is designed to have a low footprint on services code.
  at all since they are just simple functions with annotations
  set as a property.
 
-[See in context](./src/index.ts#L159-L175)
+[See in context](./src/index.ts#L153-L169)
 
 
 
@@ -39,7 +39,7 @@ A service provider is full of state since its concern is
  [encapsulate](https://en.wikipedia.org/wiki/Encapsulation_(computer_programming))
  your application global states.
 
-[See in context](./src/index.ts#L177-L186)
+[See in context](./src/index.ts#L171-L180)
 
 
 
@@ -79,7 +79,7 @@ The `?` flag indicates an optional dependency.
 It allows to write generic services with fixed
  dependencies and remap their name at injection time.
 
-[See in context](./src/util.ts#L1248-L1257)
+[See in context](./src/util.ts#L1250-L1259)
 
 
 
@@ -107,7 +107,7 @@ Initializers can be of three types:
   executions silos using them (we will cover this
   topic later on).
 
-[See in context](./src/index.ts#L257-L280)
+[See in context](./src/index.ts#L247-L270)
 
 
 
@@ -123,7 +123,7 @@ Depending on your application design, you could run it
  in only one execution silo or into several ones
  according to the isolation level your wish to reach.
 
-[See in context](./src/index.ts#L547-L557)
+[See in context](./src/index.ts#L540-L550)
 
 
 
@@ -159,5 +159,5 @@ Sadly TypeScript does not allow to add generic types
 For more details, see:
 https://stackoverflow.com/questions/64948037/generics-type-loss-while-infering/64950184#64950184
 
-[See in context](./src/util.ts#L1319-L1330)
+[See in context](./src/util.ts#L1321-L1332)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2862,9 +2862,9 @@
       "dev": true
     },
     "array-back": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
-      "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.0.tgz",
+      "integrity": "sha512-mixVv03GOOn/ubHE4STQ+uevX42ETdk0JoMVEjNkSOCT7WgERh7C8/+NyhWYNpE3BN69pxFyJIBcF7CxWz/+4A==",
       "dev": true
     },
     "array-filter": {
@@ -2972,18 +2972,18 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==",
       "dev": true,
       "requires": {
         "tslib": "^2.0.1"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
           "dev": true
         }
       }
@@ -3839,6 +3839,14 @@
         "array-back": "^4.0.1",
         "fs-then-native": "^2.0.0",
         "mkdirp2": "^1.0.4"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+          "dev": true
+        }
       }
     },
     "cacheable-lookup": {
@@ -3980,12 +3988,12 @@
       "dev": true
     },
     "catharsis": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
-      "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "^4.17.15"
       }
     },
     "caw": {
@@ -4373,12 +4381,12 @@
       }
     },
     "command-line-args": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
-      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.0.tgz",
+      "integrity": "sha512-4zqtU1hYsSJzcJBOcNZIbW5Fbk9BkjCp1pZVhQKoRaWL5J7N4XphDLwo8aWwdQpTugxwu+jf9u2ZhkXiqp5Z6A==",
       "dev": true,
       "requires": {
-        "array-back": "^3.0.1",
+        "array-back": "^3.1.0",
         "find-replace": "^3.0.0",
         "lodash.camelcase": "^4.3.0",
         "typical": "^4.0.0"
@@ -5701,29 +5709,35 @@
       }
     },
     "dmd": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/dmd/-/dmd-5.0.2.tgz",
-      "integrity": "sha512-npXsE2+/onRPk/LCrUmx7PcUSqcSVnbrDDMi2nBSawNZ8QXlHE/8xaEZ6pNqPD1lQZv8LGr1xEIpyxP336xyfw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/dmd/-/dmd-6.0.0.tgz",
+      "integrity": "sha512-PwWZlqZnJPETwqZZ70haRa+UDZcD5jeBD3ywW1Kf+jYYv0MHu/S7Ri9jsSoeTMwkcMVW9hXOMA1IZUMEufBhOg==",
       "dev": true,
       "requires": {
-        "array-back": "^4.0.1",
+        "array-back": "^5.0.0",
         "cache-point": "^2.0.0",
         "common-sequence": "^2.0.0",
         "file-set": "^4.0.1",
-        "handlebars": "^4.7.6",
-        "marked": "^1.1.0",
+        "handlebars": "^4.7.7",
+        "marked": "^2.0.0",
         "object-get": "^2.1.1",
         "reduce-flatten": "^3.0.0",
         "reduce-unique": "^2.0.1",
         "reduce-without": "^1.0.1",
         "test-value": "^3.0.0",
-        "walk-back": "^4.0.0"
+        "walk-back": "^5.0.0"
       },
       "dependencies": {
+        "array-back": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-5.0.0.tgz",
+          "integrity": "sha512-kgVWwJReZWmVuWOQKEOohXKJX+nD02JAZ54D1RRWlv8L0NebauKAaFxACKzB74RTclt1+WNz5KHaLRDAPZbDEw==",
+          "dev": true
+        },
         "reduce-flatten": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-3.0.0.tgz",
-          "integrity": "sha512-eczl8wAYBxJ6Egl6I1ECIF+8z6sHu+KE7BzaEDZTpPXKXfy9SUDQlVYwkRcNTjJLC3Iakxbhss50KuT/R6SYfg==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-3.0.1.tgz",
+          "integrity": "sha512-bYo+97BmUUOzg09XwfkwALt4PQH1M5L0wzKerBt6WLm3Fhdd43mMS89HiT1B9pJIqko/6lWx3OnV4J9f2Kqp5Q==",
           "dev": true
         }
       }
@@ -10393,65 +10407,74 @@
       }
     },
     "js2xmlparser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.1.tgz",
-      "integrity": "sha512-KrPTolcw6RocpYjdC7pL7v62e55q7qOMHvLX1UCLc5AAS8qeJ6nukarEJAF2KL2PZxlbGueEbINqZR2bDe/gUw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
+      "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
       "dev": true,
       "requires": {
-        "xmlcreate": "^2.0.3"
+        "xmlcreate": "^2.0.4"
       }
     },
     "jsarch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jsarch/-/jsarch-3.0.0.tgz",
-      "integrity": "sha512-3yDVHelMFvS7mrIDULKKe30FbFsdkl5djOq/6nSH0m9E6LD+ovNh+bjkIqkfmlFjGGz2FuPL715UPmrAhkyX7Q==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsarch/-/jsarch-4.0.1.tgz",
+      "integrity": "sha512-IjQfXBb/XIb7CGRiobcp8R236hqwDvad5KtDFoSm4LpwPh2MclMc3eAeM+UaFa+aWM86m1/pLcHVhu2YocHOMA==",
       "dev": true,
       "requires": {
-        "@babel/parser": "^7.9.6",
-        "ast-types": "^0.13.3",
+        "@babel/parser": "^7.13.15",
+        "ast-types": "^0.14.2",
         "bluebird": "^3.7.2",
-        "commander": "^2.20.0",
-        "debug": "^4.1.1",
+        "commander": "^7.2.0",
+        "debug": "^4.3.1",
         "deep-extend": "^0.6.0",
         "glob": "^7.1.6",
-        "knifecycle": "^9.1.1",
+        "knifecycle": "^11.1.0",
         "packagerc": "^1.1.0",
-        "pkg-dir": "^4.2.0",
-        "yerror": "^5.0.0"
+        "pkg-dir": "^5.0.0",
+        "yerror": "^6.0.0"
       },
       "dependencies": {
         "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
           "dev": true
         },
         "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
           "dev": true,
           "requires": {
-            "locate-path": "^5.0.0",
+            "locate-path": "^6.0.0",
             "path-exists": "^4.0.0"
           }
         },
         "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
           "dev": true,
           "requires": {
-            "p-locate": "^4.1.0"
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
           }
         },
         "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
           "dev": true,
           "requires": {
-            "p-limit": "^2.2.0"
+            "p-limit": "^3.0.2"
           }
         },
         "path-exists": {
@@ -10461,19 +10484,13 @@
           "dev": true
         },
         "pkg-dir": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+          "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
           "dev": true,
           "requires": {
-            "find-up": "^4.0.0"
+            "find-up": "^5.0.0"
           }
-        },
-        "yerror": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/yerror/-/yerror-5.0.0.tgz",
-          "integrity": "sha512-b4I0lhWrHDcFGVSP5SkSqGL8P+cuIvmoGvWfnm7YLMWMvUwngCZy9qNLjRbnABh02K/q/yFzBBz8dQuUVEoMAw==",
-          "dev": true
         }
       }
     },
@@ -10484,37 +10501,31 @@
       "dev": true
     },
     "jsdoc": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.6.tgz",
-      "integrity": "sha512-znR99e1BHeyEkSvgDDpX0sTiTu+8aQyDl9DawrkOGZTTW8hv0deIFXx87114zJ7gRaDZKVQD/4tr1ifmJp9xhQ==",
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.7.tgz",
+      "integrity": "sha512-sxKt7h0vzCd+3Y81Ey2qinupL6DpRSZJclS04ugHDNmRUXGzqicMJ6iwayhSA0S0DwwX30c5ozyUthr1QKF6uw==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.9.4",
         "bluebird": "^3.7.2",
-        "catharsis": "^0.8.11",
+        "catharsis": "^0.9.0",
         "escape-string-regexp": "^2.0.0",
         "js2xmlparser": "^4.0.1",
         "klaw": "^3.0.0",
         "markdown-it": "^10.0.0",
         "markdown-it-anchor": "^5.2.7",
-        "marked": "^0.8.2",
+        "marked": "^2.0.3",
         "mkdirp": "^1.0.4",
         "requizzle": "^0.2.3",
         "strip-json-comments": "^3.1.0",
         "taffydb": "2.6.2",
-        "underscore": "~1.10.2"
+        "underscore": "~1.13.1"
       },
       "dependencies": {
         "escape-string-regexp": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-          "dev": true
-        },
-        "marked": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-          "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
           "dev": true
         },
         "strip-json-comments": {
@@ -10526,49 +10537,49 @@
       }
     },
     "jsdoc-api": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-6.0.0.tgz",
-      "integrity": "sha512-zvfB63nAc9e+Rv2kKmJfE6tmo4x8KFho5vKr6VfYTlCCgqtrfPv0McCdqT4betUT9rWtw0zGkNUVkVqeQipY6Q==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-7.1.0.tgz",
+      "integrity": "sha512-yjIiZa6LFOgd0dyFW/R+3unnVUhhbU1CeBhisgjBPRHkar83rkgDtTMRdgQotSvt+pGlmknZqfwR5AQuMh9/6w==",
       "dev": true,
       "requires": {
-        "array-back": "^4.0.1",
+        "array-back": "^6.2.0",
         "cache-point": "^2.0.0",
-        "collect-all": "^1.0.3",
-        "file-set": "^4.0.1",
+        "collect-all": "^1.0.4",
+        "file-set": "^4.0.2",
         "fs-then-native": "^2.0.0",
-        "jsdoc": "^3.6.4",
-        "object-to-spawn-args": "^2.0.0",
+        "jsdoc": "^3.6.7",
+        "object-to-spawn-args": "^2.0.1",
         "temp-path": "^1.0.0",
-        "walk-back": "^4.0.0"
+        "walk-back": "^5.1.0"
       }
     },
     "jsdoc-parse": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-5.0.0.tgz",
-      "integrity": "sha512-Khw8c3glrTeA3/PfUJUBvhrMhWpSClORBUvL4pvq2wFcqvUVmA96wxnMkCno2GfZY4pnd8BStK5WGKGyn4Vckg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-6.0.1.tgz",
+      "integrity": "sha512-ij3Az5y2dp+ajMxYnEJH7kjKK5v6+yZ3Cg/KtRdoT15pIm6qTk/W8q72QdNLZ9jQm/U2/ifENFXXTOe6xIxGeA==",
       "dev": true,
       "requires": {
-        "array-back": "^4.0.1",
+        "array-back": "^6.1.1",
         "lodash.omit": "^4.5.0",
         "lodash.pick": "^4.4.0",
         "reduce-extract": "^1.0.0",
-        "sort-array": "^4.1.1",
+        "sort-array": "^4.1.4",
         "test-value": "^3.0.0"
       }
     },
     "jsdoc-to-markdown": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-6.0.1.tgz",
-      "integrity": "sha512-hUI2PAR5n/KlmQU3mAWO9i3D7jVbhyvUHfQ6oYVBt+wnnsyxpsAuhCODY1ryLOb2U9OPJd4GIK9mL2hqy7fHDg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-7.1.0.tgz",
+      "integrity": "sha512-LJAiwrUaOpPqOmllqnVVqfBZh6KI/rHHfSwL7DerTpjLQWHfpndz/JUNlF5ngYjbL4aHNf7uJ1TuXl6xGfq5rg==",
       "dev": true,
       "requires": {
-        "array-back": "^4.0.1",
+        "array-back": "^6.2.0",
         "command-line-tool": "^0.8.0",
         "config-master": "^3.1.0",
-        "dmd": "^5.0.1",
-        "jsdoc-api": "^6.0.0",
-        "jsdoc-parse": "^5.0.0",
-        "walk-back": "^4.0.0"
+        "dmd": "^6.0.0",
+        "jsdoc-api": "^7.1.0",
+        "jsdoc-parse": "^6.0.1",
+        "walk-back": "^5.1.0"
       }
     },
     "jsdom": {
@@ -10989,21 +11000,14 @@
       "dev": true
     },
     "knifecycle": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/knifecycle/-/knifecycle-9.1.1.tgz",
-      "integrity": "sha512-C0RpRM9Rm03AjLz0Pzl23jXnipLBaxuFzIBVGMLZtHGSca4kFCioavNB/lFaDDlQd4zUyHZYGiexrtyzM3yeHQ==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/knifecycle/-/knifecycle-11.1.1.tgz",
+      "integrity": "sha512-Q/giTQms4wYS4lBwKjrfZSe5MPQ65gqvvOLnATSLyHMpPQxUO4FT7BGZYr5xpDIteXVrqH+JR8JWmEhbmk20qw==",
       "dev": true,
       "requires": {
-        "debug": "^4.1.1",
-        "yerror": "^5.0.0"
-      },
-      "dependencies": {
-        "yerror": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/yerror/-/yerror-5.0.0.tgz",
-          "integrity": "sha512-b4I0lhWrHDcFGVSP5SkSqGL8P+cuIvmoGvWfnm7YLMWMvUwngCZy9qNLjRbnABh02K/q/yFzBBz8dQuUVEoMAw==",
-          "dev": true
-        }
+        "debug": "^4.3.1",
+        "type-fest": "^1.0.1",
+        "yerror": "^6.0.0"
       }
     },
     "labeled-stream-splicer": {
@@ -11465,9 +11469,9 @@
       "dev": true
     },
     "marked": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.9.tgz",
-      "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
+      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
       "dev": true
     },
     "marky": {
@@ -11988,9 +11992,9 @@
       "dev": true
     },
     "mkdirp2": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.4.tgz",
-      "integrity": "sha512-Q2PKB4ZR4UPtjLl76JfzlgSCUZhSV1AXQgAZa1qt5RiaALFjP/CDrGvFBrOz7Ck6McPcwMAxTsJvWOUjOU8XMw==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.5.tgz",
+      "integrity": "sha512-xOE9xbICroUDmG1ye2h4bZ8WBie9EGmACaco8K8cx6RlkJJrxGIqjGqztAI+NMhexXBcdGbSEzI6N3EJPevxZw==",
       "dev": true
     },
     "mocha": {
@@ -15913,9 +15917,9 @@
       }
     },
     "underscore": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
@@ -16228,9 +16232,9 @@
       }
     },
     "walk-back": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-4.0.0.tgz",
-      "integrity": "sha512-kudCA8PXVQfrqv2mFTG72vDBRi8BKWxGgFLwPpzHcpZnSwZk93WMwUDVcLHWNsnm+Y0AC4Vb6MUNRgaHfyV2DQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-5.1.0.tgz",
+      "integrity": "sha512-Uhxps5yZcVNbLEAnb+xaEEMdgTXl9qAQDzKYejG2AZ7qPwRQ81lozY9ECDbjLPNWm7YsO1IK5rsP1KoQzXAcGA==",
       "dev": true
     },
     "walker": {
@@ -16544,9 +16548,9 @@
       "dev": true
     },
     "xmlcreate": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.3.tgz",
-      "integrity": "sha512-HgS+X6zAztGa9zIK3Y3LXuJes33Lz9x+YyTxgrkIdabu2vqcGOWwdfCpf1hWLRrd553wd4QCDf6BBO6FfdsRiQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
+      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
       "dev": true
     },
     "xtend": {

--- a/src/build.test.ts
+++ b/src/build.test.ts
@@ -57,16 +57,15 @@ describe('buildInitializer', () => {
   );
 
   it('should build an initialization module', async () => {
-    const $ = new Knifecycle<{
-      buildInitializer: BuildInitializer;
-      PWD: string;
-    }>();
+    const $ = new Knifecycle();
 
     $.register(constant('PWD', '~/my-project'));
     $.register(initAutoloader);
     $.register(initInitializerBuilder);
 
-    const { buildInitializer } = await $.run(['buildInitializer']);
+    const { buildInitializer } = await $.run<{
+      buildInitializer: BuildInitializer;
+    }>(['buildInitializer']);
 
     const content = await buildInitializer(['dep1', 'finalMappedDep>dep3']);
     assert.equal(
@@ -139,16 +138,15 @@ export async function initialize(services = {}) {
   });
 
   it('should allows to use commonjs', async () => {
-    const $ = new Knifecycle<{
-      buildInitializer: BuildInitializer;
-      PWD: string;
-    }>();
+    const $ = new Knifecycle();
 
     $.register(constant('PWD', '~/my-project'));
     $.register(initAutoloader);
     $.register(initInitializerBuilder);
 
-    const { buildInitializer } = await $.run(['buildInitializer']);
+    const { buildInitializer } = await $.run<{
+      buildInitializer: BuildInitializer;
+    }>(['buildInitializer']);
 
     const content = await buildInitializer(['dep1', 'finalMappedDep>dep3'], {
       modules: 'commonjs',

--- a/src/build.ts
+++ b/src/build.ts
@@ -1,6 +1,6 @@
 import { SPECIAL_PROPS, parseDependencyDeclaration, initializer } from './util';
 import { buildInitializationSequence } from './sequence';
-import type { DependencyDeclaration } from './util';
+import type { DependencyDeclaration, Initializer } from './util';
 import type { Autoloader } from '.';
 
 export type BuildOptions = { modules?: 'commonjs' | true };
@@ -53,7 +53,7 @@ export default initializer(
 async function initInitializerBuilder({
   $autoload,
 }: {
-  $autoload: Autoloader;
+  $autoload: Autoloader<Initializer<unknown, Record<string, unknown>>>;
 }) {
   return buildInitializer;
 

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -27,13 +27,14 @@ import {
 } from './util';
 import type { PromiseValue } from 'type-fest';
 import type { Provider } from './util';
+import type { Dependencies, ServiceInitializer } from '.';
 
-async function aProviderInitializer(_services: unknown) {
+async function aProviderInitializer() {
   return {
     service: 'A_PROVIDER_SERVICE',
   };
 }
-async function aServiceInitializer(_services: unknown) {
+async function aServiceInitializer() {
   return 'A_PROVIDER_SERVICE';
 }
 
@@ -56,29 +57,29 @@ describe('reuseSpecialProps', () => {
     from.$singleton = false;
     from.$extra = { httpHandler: true };
 
-    const newFn = reuseSpecialProps(from, to) as any;
+    const newFn = reuseSpecialProps(from, to);
 
     assert.notEqual(newFn, to);
-    assert.equal(newFn.$name, from.$name);
-    assert.equal(newFn.$type, from.$type);
-    assert.notEqual(newFn.$inject, from.$inject);
-    assert.deepEqual(newFn.$inject, from.$inject);
-    assert.equal(newFn.$singleton, from.$singleton);
-    assert.notEqual(newFn.$extra, from.$extra);
-    assert.deepEqual(newFn.$extra, from.$extra);
+    assert.equal((newFn as any).$name, from.$name);
+    assert.equal((newFn as any).$type, from.$type);
+    assert.notEqual((newFn as any).$inject, from.$inject);
+    assert.deepEqual((newFn as any).$inject, from.$inject);
+    assert.equal((newFn as any).$singleton, from.$singleton);
+    assert.notEqual((newFn as any).$extra, from.$extra);
+    assert.deepEqual((newFn as any).$extra, from.$extra);
 
-    const newFn2 = reuseSpecialProps(from as any, to, {
+    const newFn2 = reuseSpecialProps(from, to, {
       $name: 'yolo',
-    }) as any;
+    });
 
     assert.notEqual(newFn2, to);
-    assert.equal(newFn2.$name, 'yolo');
-    assert.equal(newFn2.$type, from.$type);
-    assert.notEqual(newFn2.$inject, from.$inject);
-    assert.deepEqual(newFn2.$inject, from.$inject);
-    assert.equal(newFn2.$singleton, from.$singleton);
-    assert.notEqual(newFn.$extra, from.$extra);
-    assert.deepEqual(newFn.$extra, from.$extra);
+    assert.equal((newFn2 as any).$name, 'yolo');
+    assert.equal((newFn2 as any).$type, from.$type);
+    assert.notEqual((newFn2 as any).$inject, from.$inject);
+    assert.deepEqual((newFn2 as any).$inject, from.$inject);
+    assert.equal((newFn2 as any).$singleton, from.$singleton);
+    assert.notEqual((newFn as any).$extra, from.$extra);
+    assert.deepEqual((newFn as any).$extra, from.$extra);
   });
 });
 
@@ -126,12 +127,16 @@ describe('wrapInitializer', () => {
         httpHandler: false,
       },
     );
-    const newInitializer = wrapInitializer(async ({ log }, service): Promise<
-      Provider<() => string>
-    > => {
-      log('Wrapping...');
-      return { service: () => service.service() + '-wrapped' };
-    }, baseProviderInitializer);
+    const newInitializer = wrapInitializer(
+      async (
+        { log }: { log: (message: string) => void },
+        service,
+      ): Promise<Provider<() => string>> => {
+        log('Wrapping...');
+        return { service: () => service.service() + '-wrapped' };
+      },
+      baseProviderInitializer,
+    );
 
     const newService = await newInitializer({ log });
     assert.equal(newService.service(), 'test-wrapped');
@@ -200,7 +205,13 @@ describe('inject', () => {
 
   it('should fail with a constant', () => {
     assert.throws(() => {
-      inject(['test'], constant('test', 'test') as any);
+      inject(
+        ['test'],
+        (constant('test', 'test') as unknown) as ServiceInitializer<
+          Dependencies,
+          unknown
+        >,
+      );
     }, /E_BAD_INJECT_IN_CONSTANT/);
   });
 });
@@ -908,7 +919,7 @@ describe('handler', () => {
 
   it('should fail with no name', () => {
     assert.throws(() => {
-      handler(() => undefined);
+      handler(async () => undefined);
     }, /E_NO_HANDLER_NAME/);
   });
 });
@@ -960,7 +971,7 @@ describe('autoHandler', () => {
 
   it('should fail for anonymous functions', () => {
     assert.throws(() => {
-      autoHandler(() => undefined);
+      autoHandler(async () => undefined);
     }, /E_AUTO_NAMING_FAILURE/);
   });
 });


### PR DESCRIPTION
Looks like is will be hard to get Knifecycle built with
 strict TypeScript typings but this step at least allows
 Knifecycle users to do so.
