### PR TITLE
refactor(api): remove handlers types

### DIFF
--- a/API.md
+++ b/API.md
@@ -36,12 +36,6 @@ initialized silo content.</p>
  builder by automatically detecting its name
  and dependencies</p>
 </dd>
-<dt><a href="#handler">handler(handlerFunction, [name], [dependencies], [options])</a> ⇒ <code>function</code></dt>
-<dd><p>Shortcut to create an initializer with a simple handler</p>
-</dd>
-<dt><a href="#autoHandler">autoHandler(handlerFunction)</a> ⇒ <code>function</code></dt>
-<dd><p>Allows to create an initializer with a simple handler automagically</p>
-</dd>
 <dt><a href="#parseDependencyDeclaration">parseDependencyDeclaration(dependencyDeclaration)</a> ⇒ <code>Object</code></dt>
 <dd><p>Explode a dependency declaration an returns its parts.</p>
 </dd>
@@ -363,61 +357,6 @@ Decorator that creates an initializer from a provider
 | --- | --- | --- |
 | providerBuilder | <code>function</code> | An async function to build the service provider |
 
-<a name="handler"></a>
-
-## handler(handlerFunction, [name], [dependencies], [options]) ⇒ <code>function</code>
-Shortcut to create an initializer with a simple handler
-
-**Kind**: global function  
-**Returns**: <code>function</code> - Returns a new initializer  
-
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| handlerFunction | <code>function</code> |  | The handler function |
-| [name] | <code>String</code> |  | The name of the handler. Default to the DI prop if exists |
-| [dependencies] | <code>Array.&lt;String&gt;</code> | <code>[]</code> | The dependencies to inject in it |
-| [options] | <code>Object</code> |  | Options attached to the built initializer |
-
-**Example**  
-```js
-import Knifecycle, { handler } from 'knifecycle';
-
-new Knifecycle()
-.register(handler(getUser, 'getUser', ['db', '?log']));
-
-const QUERY = `SELECT * FROM users WHERE id=$1`
-async function getUser({ db }, userId) {
-  const [row] = await db.query(QUERY, userId);
-
-  return row;
-}
-```
-<a name="autoHandler"></a>
-
-## autoHandler(handlerFunction) ⇒ <code>function</code>
-Allows to create an initializer with a simple handler automagically
-
-**Kind**: global function  
-**Returns**: <code>function</code> - Returns a new initializer  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| handlerFunction | <code>function</code> | The handler function |
-
-**Example**  
-```js
-import Knifecycle, { autoHandler } from 'knifecycle';
-
-new Knifecycle()
-.register(autoHandler(getUser));
-
-const QUERY = `SELECT * FROM users WHERE id=$1`
-async function getUser({ db }, userId) {
-  const [row] = await db.query(QUERY, userId);
-
-  return row;
-}
-```
 <a name="parseDependencyDeclaration"></a>
 
 ## parseDependencyDeclaration(dependencyDeclaration) ⇒ <code>Object</code>

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -37,7 +37,7 @@ It is designed to have a low footprint on services code.
 In fact, the Knifecycle API is aimed to allow to statically
  build its services load/unload code once in production.
 
-[See in context](./src/index.ts#L250-L269)
+[See in context](./src/index.ts#L244-L263)
 
 
 
@@ -52,7 +52,7 @@ A service provider is full of state since its concern is
  [encapsulate](https://en.wikipedia.org/wiki/Encapsulation_(computer_programming))
  your application global states.
 
-[See in context](./src/index.ts#L271-L280)
+[See in context](./src/index.ts#L265-L274)
 
 
 
@@ -92,7 +92,7 @@ The `?` flag indicates an optional dependency.
 It allows to write generic services with fixed
  dependencies and remap their name at injection time.
 
-[See in context](./src/util.ts#L1462-L1471)
+[See in context](./src/util.ts#L1354-L1363)
 
 
 
@@ -121,7 +121,7 @@ Initializers can be of three types:
   instanciated once for all for each executions silos using
   them (we will cover this topic later on).
 
-[See in context](./src/index.ts#L369-L393)
+[See in context](./src/index.ts#L363-L387)
 
 
 
@@ -137,7 +137,7 @@ Depending on your application design, you could run it
  in only one execution silo or into several ones
  according to the isolation level your wish to reach.
 
-[See in context](./src/index.ts#L725-L735)
+[See in context](./src/index.ts#L719-L729)
 
 
 
@@ -173,5 +173,5 @@ Sadly TypeScript does not allow to add generic types
 For more details, see:
 https://stackoverflow.com/questions/64948037/generics-type-loss-while-infering/64950184#64950184
 
-[See in context](./src/util.ts#L1532-L1543)
+[See in context](./src/util.ts#L1424-L1435)
 

--- a/README.md
+++ b/README.md
@@ -458,12 +458,6 @@ initialized silo content.</p>
  builder by automatically detecting its name
  and dependencies</p>
 </dd>
-<dt><a href="#handler">handler(handlerFunction, [name], [dependencies], [options])</a> ⇒ <code>function</code></dt>
-<dd><p>Shortcut to create an initializer with a simple handler</p>
-</dd>
-<dt><a href="#autoHandler">autoHandler(handlerFunction)</a> ⇒ <code>function</code></dt>
-<dd><p>Allows to create an initializer with a simple handler automagically</p>
-</dd>
 <dt><a href="#parseDependencyDeclaration">parseDependencyDeclaration(dependencyDeclaration)</a> ⇒ <code>Object</code></dt>
 <dd><p>Explode a dependency declaration an returns its parts.</p>
 </dd>
@@ -785,61 +779,6 @@ Decorator that creates an initializer from a provider
 | --- | --- | --- |
 | providerBuilder | <code>function</code> | An async function to build the service provider |
 
-<a name="handler"></a>
-
-## handler(handlerFunction, [name], [dependencies], [options]) ⇒ <code>function</code>
-Shortcut to create an initializer with a simple handler
-
-**Kind**: global function  
-**Returns**: <code>function</code> - Returns a new initializer  
-
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| handlerFunction | <code>function</code> |  | The handler function |
-| [name] | <code>String</code> |  | The name of the handler. Default to the DI prop if exists |
-| [dependencies] | <code>Array.&lt;String&gt;</code> | <code>[]</code> | The dependencies to inject in it |
-| [options] | <code>Object</code> |  | Options attached to the built initializer |
-
-**Example**  
-```js
-import Knifecycle, { handler } from 'knifecycle';
-
-new Knifecycle()
-.register(handler(getUser, 'getUser', ['db', '?log']));
-
-const QUERY = `SELECT * FROM users WHERE id=$1`
-async function getUser({ db }, userId) {
-  const [row] = await db.query(QUERY, userId);
-
-  return row;
-}
-```
-<a name="autoHandler"></a>
-
-## autoHandler(handlerFunction) ⇒ <code>function</code>
-Allows to create an initializer with a simple handler automagically
-
-**Kind**: global function  
-**Returns**: <code>function</code> - Returns a new initializer  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| handlerFunction | <code>function</code> | The handler function |
-
-**Example**  
-```js
-import Knifecycle, { autoHandler } from 'knifecycle';
-
-new Knifecycle()
-.register(autoHandler(getUser));
-
-const QUERY = `SELECT * FROM users WHERE id=$1`
-async function getUser({ db }, userId) {
-  const [row] = await db.query(QUERY, userId);
-
-  return row;
-}
-```
 <a name="parseDependencyDeclaration"></a>
 
 ## parseDependencyDeclaration(dependencyDeclaration) ⇒ <code>Object</code>

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,8 +35,6 @@ import {
   autoProvider,
   location,
   wrapInitializer,
-  handler,
-  autoHandler,
   parseDependencyDeclaration,
   stringifyDependencyDeclaration,
   unwrapInitializerProperties,
@@ -72,8 +70,6 @@ import type {
   Initializer,
   ServiceInitializerWrapper,
   ProviderInitializerWrapper,
-  HandlerFunction,
-  Parameters,
 } from './util.js';
 import type { BuildInitializer } from './build.js';
 import type { FatalErrorService } from './fatalError.js';
@@ -103,8 +99,6 @@ export type {
   Initializer,
   ServiceInitializerWrapper,
   ProviderInitializerWrapper,
-  HandlerFunction,
-  Parameters,
   BuildInitializer,
   FatalErrorService,
   Overrides,
@@ -141,8 +135,6 @@ export {
   provider,
   autoProvider,
   location,
-  handler,
-  autoHandler,
   parseDependencyDeclaration,
   stringifyDependencyDeclaration,
   unwrapInitializerProperties,

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -22,8 +22,6 @@ import {
   autoService,
   provider,
   autoProvider,
-  handler,
-  autoHandler,
   SPECIAL_PROPS,
   unInject,
   location,
@@ -1000,98 +998,6 @@ describe('autoProvider', () => {
     expect(newInitializer[SPECIAL_PROPS.INJECT]).toEqual([]);
     expect(newInitializer[SPECIAL_PROPS.NAME]).toEqual('mySQL');
     expect(newInitializer[SPECIAL_PROPS.TYPE]).toEqual('provider');
-  });
-});
-
-describe('handler', () => {
-  test('should work', async () => {
-    const baseName = 'sampleHandler';
-    const injectedServices = ['kikooo', 'lol'];
-    const services = {
-      kikooo: 'kikooo',
-      lol: 'lol',
-    };
-    const theInitializer = handler(sampleHandler, baseName, injectedServices);
-
-    expect((theInitializer as any).$name).toEqual(baseName);
-    expect((theInitializer as any).$inject).toEqual(injectedServices);
-
-    const theHandler = await theInitializer(services);
-    const result = await theHandler('test');
-    expect(result).toEqual({
-      deps: services,
-      args: ['test'],
-    });
-
-    async function sampleHandler(deps, ...args) {
-      return { deps, args };
-    }
-  });
-
-  test('should fail with no name', () => {
-    try {
-      handler(async () => undefined);
-      throw new YError('E_UNEXPECTED_SUCCESS');
-    } catch (err) {
-      expect((err as YError).code).toEqual('E_NO_HANDLER_NAME');
-    }
-  });
-});
-
-describe('autoHandler', () => {
-  test('should work', async () => {
-    const services = {
-      kikooo: 'kikooo',
-      lol: 'lol',
-    };
-    const theInitializer = autoHandler(sampleHandler);
-
-    expect((theInitializer as any).$name).toEqual(sampleHandler.name);
-    expect((theInitializer as any).$inject).toEqual(['kikooo', 'lol']);
-
-    const theHandler = await theInitializer(services);
-    const result = await theHandler('test');
-
-    expect(result).toEqual({
-      deps: services,
-      args: ['test'],
-    });
-
-    async function sampleHandler({ kikooo, lol }, ...args) {
-      return { deps: { kikooo, lol }, args };
-    }
-  });
-
-  test('should work with spread services', async () => {
-    const services = {
-      kikooo: 'kikooo',
-      lol: 'lol',
-    };
-    const theInitializer = autoHandler(sampleHandler);
-
-    expect((theInitializer as any).$name).toEqual(sampleHandler.name);
-    expect((theInitializer as any).$inject).toEqual(['kikooo', 'lol']);
-
-    const theHandler = await theInitializer(services);
-    const result = await theHandler('test');
-
-    expect(result).toEqual({
-      deps: services,
-      args: ['test'],
-    });
-
-    async function sampleHandler({ kikooo, lol, ...services }, ...args) {
-      return { deps: { kikooo, lol, ...services }, args };
-    }
-  });
-
-  test('should fail for anonymous functions', () => {
-    try {
-      autoHandler(async () => undefined);
-      throw new YError('E_UNEXPECTED_SUCCESS');
-    } catch (err) {
-      expect((err as YError).code).toEqual('E_AUTO_NAMING_FAILURE');
-    }
   });
 });
 


### PR DESCRIPTION
It wasn't really necessary and sometimes confusing.
To produce a function that return a function, let's
 just create a function returning a function.