### PR TITLE
feat(core): add a location special property

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -37,7 +37,7 @@ It is designed to have a low footprint on services code.
 In fact, the Knifecycle API is aimed to allow to statically
  build its services load/unload code once in production.
 
-[See in context](./src/index.ts#L213-L232)
+[See in context](./src/index.ts#L207-L226)
 
 
 
@@ -52,7 +52,7 @@ A service provider is full of state since its concern is
  [encapsulate](https://en.wikipedia.org/wiki/Encapsulation_(computer_programming))
  your application global states.
 
-[See in context](./src/index.ts#L234-L243)
+[See in context](./src/index.ts#L228-L237)
 
 
 
@@ -92,7 +92,7 @@ The `?` flag indicates an optional dependency.
 It allows to write generic services with fixed
  dependencies and remap their name at injection time.
 
-[See in context](./src/util.ts#L1372-L1381)
+[See in context](./src/util.ts#L1462-L1471)
 
 
 
@@ -121,7 +121,7 @@ Initializers can be of three types:
   instanciated once for all for each executions silos using
   them (we will cover this topic later on).
 
-[See in context](./src/index.ts#L332-L356)
+[See in context](./src/index.ts#L326-L350)
 
 
 
@@ -137,7 +137,7 @@ Depending on your application design, you could run it
  in only one execution silo or into several ones
  according to the isolation level your wish to reach.
 
-[See in context](./src/index.ts#L688-L698)
+[See in context](./src/index.ts#L682-L692)
 
 
 
@@ -157,7 +157,7 @@ For the build to work, we need:
 - the dependencies list you want to
  initialize
 
-[See in context](./src/build.ts#L37-L52)
+[See in context](./src/build.ts#L39-L54)
 
 
 
@@ -173,5 +173,5 @@ Sadly TypeScript does not allow to add generic types
 For more details, see:
 https://stackoverflow.com/questions/64948037/generics-type-loss-while-infering/64950184#64950184
 
-[See in context](./src/util.ts#L1442-L1453)
+[See in context](./src/util.ts#L1532-L1543)
 

--- a/src/build.test.ts
+++ b/src/build.test.ts
@@ -21,6 +21,10 @@ describe('buildInitializer', () => {
         inject: [],
         type: 'service',
         name: 'dep1',
+        location: {
+          url: `file://services/dep1`,
+          exportName: 'default',
+        },
       },
       aProvider,
     ),
@@ -29,6 +33,10 @@ describe('buildInitializer', () => {
         inject: ['dep1', 'NODE_ENV'],
         type: 'provider',
         name: 'dep2',
+        location: {
+          url: `file://services/dep2`,
+          exportName: 'default',
+        },
       },
       aProvider,
     ),
@@ -37,6 +45,10 @@ describe('buildInitializer', () => {
         inject: ['dep5', 'dep2', 'dep1', '?depOpt'],
         type: 'service',
         name: 'dep3',
+        location: {
+          url: `file://services/dep3`,
+          exportName: 'default',
+        },
       },
       aProvider,
     ),
@@ -45,6 +57,10 @@ describe('buildInitializer', () => {
         inject: ['dep5', 'dep2', 'dep1', '?depOpt'],
         type: 'service',
         name: 'dep4',
+        location: {
+          url: `file://services/dep4`,
+          exportName: 'default',
+        },
       },
       aProvider,
     ),
@@ -53,6 +69,10 @@ describe('buildInitializer', () => {
         inject: ['$ready'],
         type: 'service',
         name: 'dep5',
+        location: {
+          url: `file://services/dep5`,
+          exportName: 'initDep5',
+        },
       },
       aProvider,
     ),
@@ -61,6 +81,10 @@ describe('buildInitializer', () => {
         inject: [],
         type: 'service',
         name: 'dep6',
+        location: {
+          url: `file://services/dep6`,
+          exportName: 'aDep6',
+        },
       },
       aProvider,
     ),
@@ -75,10 +99,7 @@ describe('buildInitializer', () => {
     async () => {
       return async function $autoload(name) {
         return mockedDepsHash[name]
-          ? Promise.resolve({
-              path: `./services/${name}`,
-              initializer: mockedDepsHash[name],
-            })
+          ? Promise.resolve(mockedDepsHash[name])
           : Promise.reject(new YError('E_UNMATCHED_DEPENDENCY', name));
       };
     },
@@ -121,15 +142,15 @@ const $instance = {
 
 
 // Definition batch #0
-import initDep1 from './services/dep1';
+import initDep1 from 'file://services/dep1';
 const NODE_ENV = "development";
 
 // Definition batch #1
-import initDep5 from './services/dep5';
-import initDep2 from './services/dep2';
+import { initDep5 } from 'file://services/dep5';
+import initDep2 from 'file://services/dep2';
 
 // Definition batch #2
-import initDep3 from './services/dep3';
+import initDep3 from 'file://services/dep3';
 
 export async function initialize(services = {}) {
   const $fatalError = await initFatalError();
@@ -255,15 +276,15 @@ const $instance = {
 
 
 // Definition batch #0
-import initDep1 from './services/dep1';
-import initDep6 from './services/dep6';
+import initDep1 from 'file://services/dep1';
+import { aDep6 as initDep6 } from 'file://services/dep6';
 const NODE_ENV = "development";
 
 // Definition batch #1
-import initDep2 from './services/dep2';
+import initDep2 from 'file://services/dep2';
 
 // Definition batch #2
-import initDep4 from './services/dep4';
+import initDep4 from 'file://services/dep4';
 
 export async function initialize(services = {}) {
   const $fatalError = await initFatalError();
@@ -384,16 +405,16 @@ const $instance = {
 
 
 // Definition batch #0
-import initDep1 from './services/dep1';
+import initDep1 from 'file://services/dep1';
 const NODE_ENV = "development";
 const $siloContext = undefined;
 
 // Definition batch #1
-import initDep5 from './services/dep5';
-import initDep2 from './services/dep2';
+import { initDep5 } from 'file://services/dep5';
+import initDep2 from 'file://services/dep2';
 
 // Definition batch #2
-import initDep3 from './services/dep3';
+import initDep3 from 'file://services/dep3';
 
 export async function initialize(services = {}) {
   const $fatalError = await initFatalError();

--- a/src/dispose.ts
+++ b/src/dispose.ts
@@ -3,6 +3,7 @@ import {
   NO_PROVIDER,
   SILO_CONTEXT,
   SPECIAL_PROPS,
+  location,
   parseDependencyDeclaration,
   service,
 } from './util.js';
@@ -151,4 +152,7 @@ async function initDispose({
   };
 }
 
-export default service(initDispose, DISPOSE, [INSTANCE, SILO_CONTEXT]);
+export default location(
+  service(initDispose, DISPOSE, [INSTANCE, SILO_CONTEXT]),
+  import.meta.url,
+);

--- a/src/fatalError.ts
+++ b/src/fatalError.ts
@@ -1,5 +1,5 @@
 import { printStackTrace } from 'yerror';
-import { service } from './util.js';
+import { location, service } from './util.js';
 import initDebug from 'debug';
 
 const debug = initDebug('knifecycle');
@@ -57,4 +57,7 @@ async function initFatalError(): Promise<FatalErrorService> {
   };
 }
 
-export default service(initFatalError, FATAL_ERROR, [], true);
+export default location(
+  service(initFatalError, FATAL_ERROR, [], true),
+  import.meta.url,
+);

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -26,6 +26,7 @@ import {
   autoHandler,
   SPECIAL_PROPS,
   unInject,
+  location,
 } from './util.js';
 import type { Provider } from './util.js';
 import type { Dependencies, ServiceInitializer } from './index.js';
@@ -344,6 +345,36 @@ describe('autoInject', () => {
     expect(newInitializer).not.toEqual(baseProvider);
     expect(newInitializer[SPECIAL_PROPS.INJECT]).not.toBe(dependencies);
     expect(newInitializer[SPECIAL_PROPS.INJECT]).toEqual(dependencies);
+  });
+
+  test('should allow to decorate a service initializer with its location', () => {
+    async function baseService({ ENV, mysql: db }) {
+      return { my: 'service' };
+    }
+
+    const newInitializer = location(
+      autoService(baseService),
+      'file://here',
+      'prop',
+    );
+
+    expect(newInitializer).not.toEqual(baseService);
+    expect(newInitializer[SPECIAL_PROPS.LOCATION]).toEqual({
+      url: 'file://here',
+      exportName: 'prop',
+    });
+  });
+
+  test('should allow to decorate a constant initializer with its location', () => {
+    const baseConstant = constant('test', 'test');
+    const newConstant = location(baseConstant, 'file://here');
+
+    expect(newConstant).not.toEqual(baseConstant);
+    expect(newConstant[SPECIAL_PROPS.TYPE]).toEqual('constant');
+    expect(newConstant[SPECIAL_PROPS.LOCATION]).toEqual({
+      url: 'file://here',
+      exportName: 'default',
+    });
   });
 
   test('should allow to decorate an initializer with optional dependencies', () => {
@@ -709,9 +740,7 @@ describe('extra', () => {
     );
 
     expect(newInitializer).not.toEqual(aProviderInitializer);
-    expect(newInitializer[SPECIAL_PROPS.EXTRA]).not.toBe(
-      baseExtraInformations,
-    );
+    expect(newInitializer[SPECIAL_PROPS.EXTRA]).not.toBe(baseExtraInformations);
     expect(newInitializer[SPECIAL_PROPS.EXTRA]).not.toEqual(
       additionalExtraInformations,
     );


### PR DESCRIPTION
In order to have a better build experience, adding the location for importing it in the initializer properties.

BREAKING CHANGE: The build will need to be adapted to match this new feature. The autoloader service signature changed. Also the utils now provide a location decorator to allow you to create modules declaring their own location.

fix #136
